### PR TITLE
fix: reduce notion page size

### DIFF
--- a/src/fetching.ts
+++ b/src/fetching.ts
@@ -324,6 +324,7 @@ export async function handlePaginatedRelations(
       page_id: pageId,
       property_id: propertyId,
       start_cursor: cursor,
+      page_size: 25,
     });
 
     if (response.type === "property_item") {


### PR DESCRIPTION
## Ticket
https://trello.com/c/UaiUFAEK

## Description
- Reduce page properties query page size from 100 to 25 to prevent rate limit issues due to heavy content size

[Rate limit docs](https://developers.notion.com/reference/request-limits#:~:text=The%20rate%20limit%20for%20incoming,the%20average%20rate%20are%20allowed.)